### PR TITLE
Upgrade Swagger to 1.5.9 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <commons-fileupload.version>1.2.1</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.swagger.version>1.5.6</io.swagger.version>
+        <io.swagger.version>1.5.9</io.swagger.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.mail.version>1.4.4</javax.mail.version>


### PR DESCRIPTION
Swagger 1.5.9 fixes a bug that not allowed to work with https, by setting "http" scheme in configuration, and unable to override it.

Merge only after these CQ approval:

https://dev.eclipse.org/ipzilla/show_bug.cgi?id=11517 - swagger-core
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=11519 - swagger-annotations
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=11523 - swagger-models
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=11524 - swagger-jaxrs
