### PR TITLE
CHE-2533 use newest versions Tomcat and commons-fileupload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
-        <commons-fileupload.version>1.2.1</commons-fileupload.version>
+        <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <io.swagger.version>1.5.9</io.swagger.version>
@@ -67,7 +67,7 @@
         <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
         <org.apache.lucene.version>5.2.1</org.apache.lucene.version>
         <org.apache.tika.version>1.11</org.apache.tika.version>
-        <org.apache.tomcat.version>8.0.32</org.apache.tomcat.version>
+        <org.apache.tomcat.version>8.0.37</org.apache.tomcat.version>
         <org.bouncycastle.version>1.51</org.bouncycastle.version>
         <org.eclipse.birt.equinox.common.version>3.6.200.v20130402-1505</org.eclipse.birt.equinox.common.version>
         <org.eclipse.core.commands.version>3.6.0</org.eclipse.core.commands.version>


### PR DESCRIPTION
Upgrade Apache Tomcat and commons-fileupload to resolve security issues from https://github.com/eclipse/che/issues/2533
