### PR TITLE
CHE-55: Adding io.fabric8 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
+        <io.fabric8.kubernetes-client>1.4.31</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>1.0.65</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>1.4.31</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <io.typefox.lsapi.version>0.3.0</io.typefox.lsapi.version>
         <javax.annotation.version>1.2</javax.annotation.version>
@@ -389,6 +392,33 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${io.fabric8.kubernetes-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>generex</artifactId>
+                        <groupId>com.github.mifmif</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model</artifactId>
+                <version>${io.fabric8.kubernetes-model}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>jackson-module-jaxb-annotations</artifactId>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+             <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>openshift-client</artifactId>
+                <version>${io.fabric8.openshift-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>


### PR DESCRIPTION
The change is coupled with PR - https://github.com/eclipse/che/pull/3381
While building "plugin-docker" without "skip-enforce" profile I got the following error:

```
[WARNING] Used undeclared dependencies found:
[WARNING]    io.fabric8:kubernetes-model:jar:1.0.63:compile
[WARNING]    io.fabric8:kubernetes-client:jar:1.4.26:compile
[INFO] Add the following to your pom to correct the missing dependencies: 
[INFO] 
<dependency>
  <groupId>io.fabric8</groupId>
  <artifactId>kubernetes-model</artifactId>
  <version>1.0.63</version>
</dependency>
<dependency>
  <groupId>io.fabric8</groupId>
  <artifactId>kubernetes-client</artifactId>
  <version>1.4.26</version>
</dependency> 
```
In order to make it work I had to add those dependencies to pom.xml even though only "openshift-client" is required. Both kubernetes-client & openshift-client are located in the same repository and the CQ allows to proceed with checkin. However, kubernetes-model is located in different one and no CQ has been created for it. Do we need to create one even though it is not used directly ?  

mvn dependency:tree
```
[INFO] +- io.fabric8:openshift-client:jar:1.4.26:compile
[INFO] |  \- io.fabric8:kubernetes-client:jar:1.4.26:compile
[INFO] |     +- io.fabric8:kubernetes-model:jar:1.0.63:compile
[INFO] |     |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.7.5:compile
[INFO] |     +- com.squareup.okhttp3:okhttp:jar:3.4.1:compile
[INFO] |     |  \- com.squareup.okio:okio:jar:1.9.0:compile
[INFO] |     +- com.squareup.okhttp3:logging-interceptor:jar:3.4.1:compile
[INFO] |     +- com.squareup.okhttp3:okhttp-ws:jar:3.4.1:compile
[INFO] |     +- org.slf4j:jul-to-slf4j:jar:1.7.6:compile
[INFO] |     +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.5.0:compile
[INFO] |     +- com.fasterxml.jackson.core:jackson-databind:jar:2.5.0:compile
[INFO] |     |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0:compile
[INFO] |     +- com.fasterxml.jackson.core:jackson-core:jar:2.5.0:compile
[INFO] |     +- io.fabric8:zjsonpatch:jar:0.2.3:compile
[INFO] |     \- com.github.mifmif:generex:jar:1.0.1:compile
[INFO] |        \- dk.brics.automaton:automaton:jar:1.11-8:compile
```

CQ - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12209
Jira - https://issues.jboss.org/browse/CHE-55

