### PR TITLE
Upgrade to GWT 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <com.fasterxml.jackson.core.version>2.5.0</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.19.1</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
-        <com.google.guava.version>18.0</com.google.guava.version>
+        <com.google.guava.version>20.0</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>${version.gwt.plugin}</com.google.gwt.version>
         <com.google.http-client.version>1.19.0</com.google.http-client.version>
@@ -97,7 +97,7 @@
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.reflections.version>0.9.9</org.reflections.version>
         <org.slf4j.version>1.7.6</org.slf4j.version>
-        <org.vectomatic.lib-gwt-svg.version>0.5.10</org.vectomatic.lib-gwt-svg.version>
+        <org.vectomatic.lib-gwt-svg.version>0.5.12</org.vectomatic.lib-gwt-svg.version>
         <org.yaml.snakeyaml.version>1.14</org.yaml.snakeyaml.version>
         <?SORTPOM IGNORE?>
         <!-- compile time dependencies-->
@@ -231,6 +231,52 @@
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-dev</artifactId>
                 <version>${com.google.gwt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>asm</artifactId>
+                        <groupId>org.ow2.asm</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-collections</artifactId>
+                        <groupId>commons-collections</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>xml-apis</artifactId>
+                        <groupId>xml-apis</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>httpclient</artifactId>
+                        <groupId>org.apache.httpcomponents</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jetty-http</artifactId>
+                        <groupId>org.eclipse.jetty</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jetty-io</artifactId>
+                        <groupId>org.eclipse.jetty</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jetty-util</artifactId>
+                        <groupId>org.eclipse.jetty</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>asm-commons</artifactId>
+                        <groupId>org.ow2.asm</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jetty-servlet</artifactId>
+                        <groupId>org.eclipse.jetty</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>httpmime</artifactId>
+                        <groupId>org.apache.httpcomponents</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
### What does this PR do?

- Change `guava` version
- Change `lib-gwt-svg` version
- Exclude unnecessary deps

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2869

### Changelog
Changelog: Upgraded GWT to version 2.8 including new `guava` and `lib-gwt-svg`.
