### PR TITLE
Update everrest to 1.13.3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
-        <org.everrest.version>1.13.1</org.everrest.version>
+        <org.everrest.version>1.13.3</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>


### PR DESCRIPTION
### What does this PR do?
Update everrest to 1.13.3 version.

Approved CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12671

#### Changelog
Update everrest from 1.13.1 to 1.13.3

#### Release Notes
Update everrest from 1.13.1 to 1.13.3

#### Docs PR
N/A
