### PR TITLE
Update kubernetes-client to 2.1.1 (CQ 12789)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.1.2</ch.qos.logback.version>
-        <com.fasterxml.jackson.core.version>2.5.0</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.19.1</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
         <com.google.guava.version>20.0</com.google.guava.version>
@@ -50,9 +50,9 @@
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>1.4.31</io.fabric8.kubernetes-client>
-        <io.fabric8.kubernetes-model>1.0.65</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>1.4.31</io.fabric8.openshift-client.version>
+        <io.fabric8.kubernetes-client>2.1.1</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>2.1.1</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <io.typefox.lsapi.version>0.3.0</io.typefox.lsapi.version>
         <javax.annotation.version>1.2</javax.annotation.version>


### PR DESCRIPTION
### What does this PR do?

Update fabric8io kubernetes-client and openshift-client for some bugfixes.

### Changelog
Updated kubernetes-client and openshift-client from 1.4.31 to 2.1.1 

CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12789