### PR TITLE
[OpenShift] Update to snapshot version 5.6.0-openshift-connector-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>org.eclipse.che.depmgt</groupId>
     <artifactId>maven-depmgt-pom</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Dependency Management POM</name>
     <description>Provides version of third parties artifacts to use in Codenvy platform projects</description>


### PR DESCRIPTION
### What does this PR do?
Update versions to `5.6.0-openshift-connector-SNAPSHOT`