### PR TITLE
Minor upgrade of everrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
-        <org.everrest.version>1.13.3</org.everrest.version>
+        <org.everrest.version>1.13.4</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>


### PR DESCRIPTION
### What does this PR do?
Upgrade of everest from 1.13.3 to 1.13.4
approved CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13045
everrest has only one improvement ```javax.servlet-api``` declared as provided in ```everrest-websockets```

### What issues does this PR fix or reference?

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
