### PR TITLE
Update kubernetes-client and openshift-client to 2.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>2.1.1</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-client>2.2.8</io.fabric8.kubernetes-client>
         <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>2.1.1</io.fabric8.openshift-client.version>
+        <io.fabric8.openshift-client.version>2.2.8</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <io.typefox.lsapi.version>0.3.0</io.typefox.lsapi.version>
         <javax.annotation.version>1.2</javax.annotation.version>


### PR DESCRIPTION
### What does this PR do?
Updates kubernetes-client and openshift-client to 2.2.8.