### PR TITLE
Updating okhttp version to 3.6.0 for matching k8s client 2.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
         <com.h2database.version>1.4.192</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
-        <com.squareup.okhttp3.version>3.4.2</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.6.0</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.2</commons-fileupload.version>


### PR DESCRIPTION
### What does this PR do?
Adds matching version of okhhtp to 2.2.8 version of the k8s client from - 
https://github.com/eclipse/che-dependencies/pull/38

### What issues does this PR fix or reference?
No issue, but it is updates okhhtp for https://github.com/eclipse/che-dependencies/pull/38

### Previous behavior
Dashboard is not loading with the following trace -  https://pastebin.com/bLjp1xLw
