### PR TITLE
Upgrade: tomcat, slf4j, logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </scm>
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
-        <ch.qos.logback.version>1.1.2</ch.qos.logback.version>
+        <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.fasterxml.jackson.core.version>2.5.0</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.19.1</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
@@ -71,7 +71,7 @@
         <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
         <org.apache.lucene.version>5.2.1</org.apache.lucene.version>
         <org.apache.tika.version>1.11</org.apache.tika.version>
-        <org.apache.tomcat.version>8.0.38</org.apache.tomcat.version>
+        <org.apache.tomcat.version>8.5.11</org.apache.tomcat.version>
         <org.bouncycastle.version>1.51</org.bouncycastle.version>
         <org.eclipse.birt.equinox.common.version>3.6.200.v20130402-1505</org.eclipse.birt.equinox.common.version>
         <org.eclipse.core.commands.version>3.6.0</org.eclipse.core.commands.version>
@@ -96,7 +96,7 @@
         <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.reflections.version>0.9.9</org.reflections.version>
-        <org.slf4j.version>1.7.6</org.slf4j.version>
+        <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.vectomatic.lib-gwt-svg.version>0.5.12</org.vectomatic.lib-gwt-svg.version>
         <org.yaml.snakeyaml.version>1.14</org.yaml.snakeyaml.version>
         <requirejs.upstream.version>2.1.15</requirejs.upstream.version>


### PR DESCRIPTION
### What does this PR do?
Upgrade of
- tomcat 8.5.11 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12835
- logback-classic 1.2.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12836
- logback-core 1.2.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12837
- logback-access 1.2.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12838
 - slf4j-api 1.7.24  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12839
 - log4j-over-slf4 1.7.24  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12841
 - jul-to-slf4j 1.7.24 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12842
-  jcl-over-slf4j 1.7.24 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12843
-  slf4j-simple 1.7.24 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12843


### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1731

