### PR TITLE
Migration  from typefox.lsapi to lsp4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
+        <org.eclipse.xtext.version>2.10.0</org.eclipse.xtext.version>
         <org.everrest.version>1.13.4</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
@@ -945,12 +946,12 @@
             <dependency>
                 <groupId>org.eclipse.xtext</groupId>
                 <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
-                <version>2.10.0</version>
+                <version>${org.eclipse.xtext.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.xtext</groupId>
                 <artifactId>org.eclipse.xtext.xbase.lib.gwt</artifactId>
-                <version>2.10.0</version>
+                <version>${org.eclipse.xtext.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.everrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <io.fabric8.kubernetes-model>1.0.65</io.fabric8.kubernetes-model>
         <io.fabric8.openshift-client.version>1.4.31</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
-        <io.typefox.lsapi.version>0.3.0</io.typefox.lsapi.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.mail.version>1.4.4</javax.mail.version>
@@ -65,6 +64,7 @@
         <jdbc.postgresql-driver.version>9.4-1201-jdbc41</jdbc.postgresql-driver.version>
         <joda-time.version>2.3</joda-time.version>
         <log4j.version>1.2.17</log4j.version>
+        <lsp4j.version>0.1.2</lsp4j.version>
         <net.java.dev.jna.version>4.1.0</net.java.dev.jna.version>
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>
@@ -886,6 +886,16 @@
                 <version>${org.eclipse.jgit.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.lsp4j</groupId>
+                <artifactId>org.eclipse.lsp4j</artifactId>
+                <version>${lsp4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.lsp4j</groupId>
+                <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
+                <version>${lsp4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>eclipselink</artifactId>
                 <version>${org.eclipse.persistence.eclipselink.version}</version>
@@ -931,6 +941,16 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
                 <version>${org.eclipse.osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.xtext</groupId>
+                <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.xtext</groupId>
+                <artifactId>org.eclipse.xtext.xbase.lib.gwt</artifactId>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.everrest</groupId>


### PR DESCRIPTION
This PR exchanges the managed dependencies for the typefox LSP API for the corresponding LSP4J dependencies.

**WS agent server**
Added
```
[INFO] |  \- org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:jar:0.1.2:compile
[INFO] +- org.eclipse.lsp4j:org.eclipse.lsp4j:jar:0.1.2:compile
[INFO] |  \- org.eclipse.lsp4j:org.eclipse.lsp4j.generator:jar:0.1.2:compile
[INFO] |     \- org.eclipse.xtend:org.eclipse.xtend.lib:jar:2.10.0:compile
[INFO] |        \- org.eclipse.xtend:org.eclipse.xtend.lib.macro:jar:2.10.0:compile
[INFO] +- org.eclipse.xtext:org.eclipse.xtext.xbase.lib:jar:2.10.0:compile
```
Removed
```
[INFO] |  +- io.typefox.lsapi:io.typefox.lsapi:jar:0.3.0:compile
[INFO] |  |  \- io.typefox.lsapi:io.typefox.lsapi.annotations:jar:0.3.0:compile
[INFO] |  +- io.typefox.lsapi:io.typefox.lsapi.services:jar:0.3.0:compile
[INFO] |  |  \- org.eclipse.xtend:org.eclipse.xtend.lib:jar:2.10.0:compile
[INFO] |  |     +- org.eclipse.xtext:org.eclipse.xtext.xbase.lib:jar:2.10.0:compile
[INFO] |  |     \- org.eclipse.xtend:org.eclipse.xtend.lib.macro:jar:2.10.0:compile
```

**IDE**
Added
```
[INFO] +- org.eclipse.che.plugin:che-plugin-zend-debugger-ide:jar:5.8.0-SNAPSHOT:compile
[INFO] +- org.eclipse.lsp4j:org.eclipse.lsp4j:jar:0.1.2:compile
[INFO] |  +- org.eclipse.lsp4j:org.eclipse.lsp4j.generator:jar:0.1.2:compile
[INFO] |  \- org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:jar:0.1.2:compile
[INFO] +- org.eclipse.xtext:org.eclipse.xtext.xbase.lib.gwt:jar:2.10.0:compile
[INFO] |  \- org.eclipse.xtext:org.eclipse.xtext.xbase.lib:jar:2.10.0:compile
```
Removed
```
[INFO] |  +- io.typefox.lsapi:io.typefox.lsapi:jar:0.3.0:compile
[INFO] |  |  \- io.typefox.lsapi:io.typefox.lsapi.annotations:jar:0.3.0:compile
[INFO] |  |     \- org.eclipse.xtend:org.eclipse.xtend.lib:jar:2.10.0:compile
[INFO] |  |        +- org.eclipse.xtext:org.eclipse.xtext.xbase.lib:jar:2.10.0:compile
[INFO] |  |        \- org.eclipse.xtend:org.eclipse.xtend.lib.macro:jar:2.10.0:compile
```

See https://github.com/eclipse/che/issues/3656
Fork of https://github.com/eclipse/che-dependencies/pull/33