### PR TITLE
Update dependencies for openshift-connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <javax.websocket.api.version>1.1</javax.websocket.api.version>
         <javax.ws.rs.version>2.0</javax.ws.rs.version>
         <jdbc.postgresql-driver.version>9.4-1201-jdbc41</jdbc.postgresql-driver.version>
-        <jnr-posix.version>3.0.38</jnr-posix.version>
         <joda-time.version>2.3</joda-time.version>
         <log4j.version>1.2.17</log4j.version>
         <lsp4j.version>0.1.2</lsp4j.version>
@@ -194,11 +193,6 @@
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
                 <version>${com.fasterxml.jackson.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-posix</artifactId>
-                <version>${jnr-posix.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api-client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
-        <com.fasterxml.jackson.core.version>2.5.0</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.19.1</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
         <com.google.guava.version>20.0</com.google.guava.version>
@@ -45,14 +45,15 @@
         <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
         <com.h2database.version>1.4.192</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
+        <com.squareup.okhttp3.version>3.6.0</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>1.4.31</io.fabric8.kubernetes-client>
-        <io.fabric8.kubernetes-model>1.0.65</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>1.4.31</io.fabric8.openshift-client.version>
+        <io.fabric8.kubernetes-client>2.2.8</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>2.2.8</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>
@@ -62,6 +63,7 @@
         <javax.websocket.api.version>1.1</javax.websocket.api.version>
         <javax.ws.rs.version>2.0</javax.ws.rs.version>
         <jdbc.postgresql-driver.version>9.4-1201-jdbc41</jdbc.postgresql-driver.version>
+        <jnr-posix.version>3.0.38</jnr-posix.version>
         <joda-time.version>2.3</joda-time.version>
         <log4j.version>1.2.17</log4j.version>
         <lsp4j.version>0.1.2</lsp4j.version>
@@ -192,6 +194,11 @@
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
                 <version>${com.fasterxml.jackson.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-posix</artifactId>
+                <version>${jnr-posix.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api-client</groupId>
@@ -415,6 +422,11 @@
                 <groupId>com.jcraft</groupId>
                 <artifactId>jsch</artifactId>
                 <version>${com.jcraft.jsch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${com.squareup.okhttp3.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.tngtech.java</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/CHE-229

* ~~com.fasterxml.jackson.core:jackson-annotations:jar:2.7.7~~ [CQ13487](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13487) approved
* ~~com.fasterxml.jackson.core:jackson-core:jar:2.7.7~~ [CQ13488](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13488) approved
* ~~com.fasterxml.jackson.core:jackson-databind:jar:2.7.7~~ [CQ13490](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13490) approved
* ~~com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.7.7~~ [CQ13489](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13489) approved
* ~~com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.7.7~~ [CQ13491](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13491) approved
* ~~com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.7.7~~ [CQ13492](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13492) approved
  * ~~com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.7.7~~ [CQ13494](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13494) approved
  * ~~com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.7.7~~ [CQ13495](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13495) approved
* ~~com.squareup.okhttp3:okhttp:jar:3.6.0~~ [CQ13481](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13481) approved
  * ~~com.squareup.okio:okio:jar:1.11.0~~ [CQ13496](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13496) approved
* ~~io.fabric8:kubernetes-client:jar:2.2.8~~ [CQ13497](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13497) approved
  * ~~com.squareup.okhttp3:logging-interceptor:jar:3.6.0~~ [CQ13481](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13481) approved
   * ~~org.slf4j:slf4j-api:jar:1.7.24~~ (already in che-dep)
   * ~~org.slf4j:jul-to-slf4j:jar:1.7.24~~ (already in che-dep)
   * ~~io.fabric8:zjsonpatch:jar:0.3.0~~ already existing [CQ12451](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12451)
 * ~~io.fabric8:kubernetes-model:jar:1.0.67~~ [CQ13499](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13499) approved
  * ~~javax.validation:validation-api:jar:1.1.0.Final~~ (already in che-dep)
 * ~~io.fabric8:openshift-client:jar:2.2.8~~ [CQ13498](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13498) approved
