### PR TITLE
Add Keycloak dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
+        <commons-logging.version>1.2</commons-logging.version>
         <io.fabric8.kubernetes-client>2.2.8</io.fabric8.kubernetes-client>
         <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
         <io.fabric8.openshift-client.version>2.2.8</io.fabric8.openshift-client.version>
@@ -70,6 +71,7 @@
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>
         <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
+        <org.apache.httpcomponents.version>4.5</org.apache.httpcomponents.version>
         <org.apache.lucene.version>5.2.1</org.apache.lucene.version>
         <org.apache.tika.version>1.11</org.apache.tika.version>
         <org.apache.tomcat.version>8.5.11</org.apache.tomcat.version>
@@ -95,6 +97,7 @@
         <org.flyway.version>4.0.3</org.flyway.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
+        <org.keycloak.version>3.1.0.Final</org.keycloak.version>
         <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.reflections.version>0.9.9</org.reflections.version>
@@ -454,6 +457,11 @@
                 <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client</artifactId>
                 <version>${io.fabric8.kubernetes-client}</version>
@@ -650,6 +658,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${org.apache.commons.lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${org.apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
@@ -1014,6 +1027,36 @@
                 <groupId>org.jdom</groupId>
                 <artifactId>jdom</artifactId>
                 <version>${org.jdom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-core</artifactId>
+                <version>${org.keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-spi</artifactId>
+                <version>${org.keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-client-registration-api</artifactId>
+                <version>${org.keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-common</artifactId>
+                <version>${org.keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-core</artifactId>
+                <version>${org.keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-servlet-adapter-spi</artifactId>
+                <version>${org.keycloak.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
### What does this PR do?
Add Keycloak related dependencies

List of related CQs:
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13864 Keycloak Servlet Filter Adapter 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13869 Keycloak Core 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13878 Keycloak Common 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13879 Keycloak Adapter SPI 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13880 Keycloak Servlet Integration 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13881 Keycloak Adapter Core 3.1.0.Final
- [ ] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13882 Keycloak Client Registration API 3.1.0.Final
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13885 commons-logging 1.2
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13886 jboss-logging 3.3.0.Final
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13887 Apache HttpComponets HttpClient 4.5

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5437
