### PR TITLE
Update to EclipseLink 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,14 @@
         <org.eclipse.jetty.version>9.3.1.v20150714</org.eclipse.jetty.version>
         <org.eclipse.jgit.version>4.3.1.201605051710-r</org.eclipse.jgit.version>
         <org.eclipse.osgi.version>3.10.0.v20140606-1445</org.eclipse.osgi.version>
-        <org.eclipse.persistence.eclipselink.version>2.6.2</org.eclipse.persistence.eclipselink.version>
-        <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
+        <org.eclipse.persistence.eclipselink.version>2.7.0</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
         <org.eclipse.xtext.version>2.10.0</org.eclipse.xtext.version>
         <org.everrest.version>1.13.5</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
+        <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
         <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
@@ -917,19 +918,18 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
-                <artifactId>eclipselink</artifactId>
-                <version>${org.eclipse.persistence.eclipselink.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commonj.sdo</artifactId>
-                        <groupId>org.eclipse.persistence</groupId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>javax.persistence</artifactId>
+                <version>${org.eclipse.persistence.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
-                <artifactId>javax.persistence</artifactId>
-                <version>${org.eclipse.persistence.version}</version>
+                <artifactId>org.eclipse.persistence.core</artifactId>
+                <version>${org.eclipse.persistence.eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa</artifactId>
+                <version>${org.eclipse.persistence.eclipselink.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.search</groupId>
@@ -1001,6 +1001,11 @@
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
                 <version>${org.flyway.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>json</artifactId>
+                <version>${org.glassfish.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
### What does this PR do?

Update to EclipseLink 2.7.0

dependencies used are
```
[INFO] +- org.eclipse.persistence:javax.persistence:jar:2.2.0:test
[INFO] +- org.eclipse.persistence:org.eclipse.persistence.core:jar:2.7.0:test
[INFO] |  +- org.eclipse.persistence:org.eclipse.persistence.asm:jar:2.7.0:test
[INFO] |  \- org.glassfish:javax.json:jar:1.0.4:test
[INFO] +- org.eclipse.persistence:org.eclipse.persistence.jpa:jar:2.7.0:test
[INFO] |  +- org.eclipse.persistence:org.eclipse.persistence.antlr:jar:2.7.0:test
[INFO] |  \- org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:jar:2.7.0:test
```

CQ for org.glassfish:javax.json:jar:1.0.4:test is https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14311
the other are eclipse dependencies.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326


Require also
- https://github.com/eclipse/che/pull/6377
and
- https://github.com/codenvy/codenvy/pull/2429