### PR TITLE
Revert "Update to EclipseLink 2.7.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,13 @@
         <org.eclipse.jetty.version>9.3.1.v20150714</org.eclipse.jetty.version>
         <org.eclipse.jgit.version>4.3.1.201605051710-r</org.eclipse.jgit.version>
         <org.eclipse.osgi.version>3.10.0.v20140606-1445</org.eclipse.osgi.version>
-        <org.eclipse.persistence.eclipselink.version>2.7.0</org.eclipse.persistence.eclipselink.version>
-        <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
+        <org.eclipse.persistence.eclipselink.version>2.6.2</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
         <org.eclipse.xtext.version>2.10.0</org.eclipse.xtext.version>
         <org.everrest.version>1.13.5</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
-        <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
         <org.javassist.version>3.18.2-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
         <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
@@ -918,18 +917,19 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink</artifactId>
+                <version>${org.eclipse.persistence.eclipselink.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commonj.sdo</artifactId>
+                        <groupId>org.eclipse.persistence</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
                 <artifactId>javax.persistence</artifactId>
                 <version>${org.eclipse.persistence.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.core</artifactId>
-                <version>${org.eclipse.persistence.eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.jpa</artifactId>
-                <version>${org.eclipse.persistence.eclipselink.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.search</groupId>
@@ -1001,11 +1001,6 @@
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
                 <version>${org.flyway.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>json</artifactId>
-                <version>${org.glassfish.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Reverts eclipse/che-dependencies#58 as https://github.com/eclipse/che/pull/6377 is not approved while I thought it was !

so either need to approve this one or the che one