### PR TITLE
Update Lucene to 7.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>
         <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
-        <org.apache.lucene.version>5.2.1</org.apache.lucene.version>
+        <org.apache.lucene.version>7.0.1</org.apache.lucene.version>
         <org.apache.tika.version>1.11</org.apache.tika.version>
         <org.apache.tomcat.version>8.5.11</org.apache.tomcat.version>
         <org.bouncycastle.version>1.51</org.bouncycastle.version>


### PR DESCRIPTION
### What does this PR do?
Update Lucene to 7.0.1 version (which is java9 compliant)

maven dependencies
```
[INFO] +- org.apache.lucene:lucene-analyzers-common:jar:7.0.1:compile
[INFO] +- org.apache.lucene:lucene-core:jar:7.0.1:compile
[INFO] +- org.apache.lucene:lucene-highlighter:jar:7.0.1:compile
[INFO] |  +- org.apache.lucene:lucene-join:jar:7.0.1:compile
[INFO] |  +- org.apache.lucene:lucene-memory:jar:7.0.1:compile
[INFO] |  \- org.apache.lucene:lucene-queries:jar:7.0.1:compile
[INFO] \- org.apache.lucene:lucene-queryparser:jar:7.0.1:compile
[INFO]    \- org.apache.lucene:lucene-sandbox:jar:7.0.1:compile
```

List of Lucene 7.0.1 CQs
https://dev.eclipse.org/ipzilla/buglist.cgi?query_format=advanced&short_desc_type=allwordssubstr&short_desc=lucene+7.0.1&product=ecd&component=ecd.che&long_desc_type=substring&long_desc=&bug_file_loc_type=allwordssubstr&bug_file_loc=&keywords_type=allwords&keywords=&emailassigned_to1=1&emailtype1=substring&email1=&emailassigned_to2=1&emailreporter2=1&emailcc2=1&emailtype2=substring&email2=&bugidtype=include&bug_id=&chfieldfrom=&chfieldto=Now&chfieldvalue=&cmdtype=doit&order=Reuse+same+sort+as+last+time&field0-0-0=noop&type0-0-0=noop&value0-0-0=

All are approved

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

### Previous behavior
older version 5.2.1 (released in 2015)

### New behavior
Allow to use with Java9 runtime

### Tests written?
No

### Docs updated?
N/A