### PR TITLE
Update javassist to 3.22.0-GA and GWT mockito to 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <com.jayway.restassured.version>2.4.0</com.jayway.restassured.version>
         <org.easytesting.fest-assert.version>1.4</org.easytesting.fest-assert.version>
         <org.hamcrest.version>1.3</org.hamcrest.version>
-        <com.google.gwt.gwtmockito>1.1.4</com.google.gwt.gwtmockito>
+        <com.google.gwt.gwtmockito>1.1.7</com.google.gwt.gwtmockito>
         <org.everrest.assured.version>${org.everrest.version}</org.everrest.assured.version>
         <junit.version>4.11</junit.version>
         <io.jsonwebtoken.jjwt.version>0.7.0</io.jsonwebtoken.jjwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <org.everrest.version>1.13.5</org.everrest.version>
         <org.flyway.version>4.0.3</org.flyway.version>
         <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
-        <org.javassist.version>3.18.2-GA</org.javassist.version>
+        <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
         <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>


### PR DESCRIPTION
### CQs
- [X] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14616
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14659

### What does this PR do?
Update javassist to a version compliant with Java9
Also update GWT mockito to 1.1.7 compliant with javassit 3.22

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

### Previous behavior
Some failures when using it with Java9

### New behavior
Fix failures with Java9

### Tests written?
No

### Docs updated?
No
