### PR TITLE
Add jsinterop-annotations dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
         <com.google.http-client.version>1.19.0</com.google.http-client.version>
+        <com.google.jsinterop.version>1.0.2</com.google.jsinterop.version>
         <com.google.oauth-client.version>1.19.0</com.google.oauth-client.version>
         <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
         <com.h2database.version>1.4.192</com.h2database.version>
@@ -273,7 +274,8 @@
                         <groupId>org.apache.httpcomponents</groupId>
                     </exclusion>
                 </exclusions>
-            </dependency>            <dependency>
+            </dependency>
+            <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-elemental</artifactId>
                 <version>${com.google.gwt.version}</version>
@@ -359,6 +361,11 @@
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
                 <version>${com.google.code.guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.jsinterop</groupId>
+                <artifactId>jsinterop-annotations</artifactId>
+                <version>${com.google.jsinterop.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.oauth-client</groupId>


### PR DESCRIPTION
### What does this PR do?
Adds `jsinterop-annotations` dependency.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7352

CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15002

`jsinterop-annotations` is needed for https://github.com/eclipse/che/pull/7515