### PR TITLE
Upgrade OpenShift Kubernetes OkHttp clients versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@
         <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
         <com.h2database.version>1.4.192</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
-        <com.squareup.okhttp3.version>3.6.0</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.8.1</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>2.2.8</io.fabric8.kubernetes-client>
-        <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>2.2.8</io.fabric8.openshift-client.version>
+        <io.fabric8.kubernetes-client>3.1.0</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>2.0.4</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>3.1.0</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
### What does this PR do?
Sets latest version of `kubernetes-client`, `kubernetes-model`, `openshift-client` and upgrades version of `OkHttpClient`.
needed for: https://github.com/eclipse/che/pull/7629

CQs:
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15029
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15030
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15031
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15032