### PR TITLE
Update dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,15 +35,15 @@
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
-        <com.google.api-client.version>1.19.1</com.google.api-client.version>
+        <com.google.api-client.version>1.23.0</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
-        <com.google.guava.version>20.0</com.google.guava.version>
+        <com.google.guava.version>23.4-jre</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
-        <com.google.http-client.version>1.19.0</com.google.http-client.version>
-        <com.google.oauth-client.version>1.19.0</com.google.oauth-client.version>
-        <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
-        <com.h2database.version>1.4.192</com.h2database.version>
+        <com.google.http-client.version>1.23.0</com.google.http-client.version>
+        <com.google.oauth-client.version>1.23.0</com.google.oauth-client.version>
+        <com.googlecode.gson.version>2.8.2</com.googlecode.gson.version>
+        <com.h2database.version>1.4.196</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
         <com.squareup.okhttp3.version>3.6.0</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
@@ -97,7 +97,7 @@
         <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
-        <org.kohsuke.github-api.version>1.73</org.kohsuke.github-api.version>
+        <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.postgresql.version>9.4-1201-jdbc41</org.postgresql.version>
         <org.reflections.version>0.9.9</org.reflections.version>
@@ -127,7 +127,7 @@
         <com.google.gwt.gwtmockito>1.1.7</com.google.gwt.gwtmockito>
         <org.everrest.assured.version>${org.everrest.version}</org.everrest.assured.version>
         <junit.version>4.11</junit.version>
-        <io.jsonwebtoken.jjwt.version>0.7.0</io.jsonwebtoken.jjwt.version>
+        <io.jsonwebtoken.jjwt.version>0.9.0</io.jsonwebtoken.jjwt.version>
         <org.apache.maven.plugin-testing-harness.version>3.3.0</org.apache.maven.plugin-testing-harness.version>
         <org.mockito.version>2.10.0</org.mockito.version>
         <org.mockitong.version>0.5</org.mockitong.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
         <org.eclipse.xtext.version>2.10.0</org.eclipse.xtext.version>
         <org.everrest.version>1.13.5</org.everrest.version>
-        <org.flyway.version>4.0.3</org.flyway.version>
+        <org.flyway.version>4.2.0</org.flyway.version>
         <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>


### PR DESCRIPTION
### What does this PR do?
Update version of various dependencies:

- [x] GitHub API - org.kohsuke github Version:1.90 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14958
- [x] jjwt Version 0.9.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14959
- [x] google-api-client Version 1.23.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14960
- [x] Google Guava 23.4-jre https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14961
- [x] google-http-client Version 1.23.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14962
- [x] google-http-client-jackson2 v1.23.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14963
- [x] google-oauth-client v1.23.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14964
- [x] gson 2.8.2 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14965
- [x] h2 database Version: 1.4.196 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14966
- [x] flyway-core 4.2.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14689