### PR TITLE
Revert guava version due to incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.23.0</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
-        <com.google.guava.version>23.4-jre</com.google.guava.version>
+        <com.google.guava.version>20.0</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
         <com.google.http-client.version>1.23.0</com.google.http-client.version>


### PR DESCRIPTION
### What does this PR do?
Reverts guava version to 20.0 due to incompatibility
