### PR TITLE
Upgrade the `kubernetes-client` library to get fixes related to websocket management.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@
         <com.googlecode.gson.version>2.3.1</com.googlecode.gson.version>
         <com.h2database.version>1.4.192</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
-        <com.squareup.okhttp3.version>3.6.0</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.7.0</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>2.2.8</io.fabric8.kubernetes-client>
-        <io.fabric8.kubernetes-model>1.0.67</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>2.2.8</io.fabric8.openshift-client.version>
+        <io.fabric8.kubernetes-client>2.3.1</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>1.0.73</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>2.3.1</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
### What does this PR do?

This PR upgrades the `kubernetes-client` and `openshift-client` libraries from the `2.2.8` to the `2.3.1` version.

### What issues does this PR fix or reference?

This is necessary to fix bugs that prevent using a single shared OkHttpClient instance (cf. https://github.com/redhat-developer/rh-che/issues/472) in the multi-tenant `rh-che` implementation.

### Related CQs

The following CQ have been opened and must be resolved before merging this PR:

https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15203
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15206
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15212
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15210
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15211
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15213
