### PR TITLE
Update GWT Mockito to 1.1.8 version which is Java9 compliant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <com.jayway.restassured.version>2.4.0</com.jayway.restassured.version>
         <org.easytesting.fest-assert.version>1.4</org.easytesting.fest-assert.version>
         <org.hamcrest.version>1.3</org.hamcrest.version>
-        <com.google.gwt.gwtmockito>1.1.7</com.google.gwt.gwtmockito>
+        <com.google.gwt.gwtmockito>1.1.8</com.google.gwt.gwtmockito>
         <org.everrest.assured.version>${org.everrest.version}</org.everrest.assured.version>
         <junit.version>4.11</junit.version>
         <io.jsonwebtoken.jjwt.version>0.9.0</io.jsonwebtoken.jjwt.version>


### PR DESCRIPTION
### What does this PR do?
Update GWT mockito to 1.1.8 version

it includes this PR fix https://github.com/google/gwtmockito/pull/73 allowing to use Java9 at compilation time

CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14659

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

### Previous behavior
Failure with Java9
