### PR TITLE
Add jsinterop base dependency that can be used when doing jsinterop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
         <com.google.http-client.version>1.23.0</com.google.http-client.version>
+        <com.google.jsinterop.base.version>1.0.0-RC1</com.google.jsinterop.base.version>
         <com.google.jsinterop.version>1.0.2</com.google.jsinterop.version>
         <com.google.oauth-client.version>1.23.0</com.google.oauth-client.version>
         <com.googlecode.gson.version>2.8.2</com.googlecode.gson.version>
@@ -361,6 +362,11 @@
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
                 <version>${com.google.code.guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.jsinterop</groupId>
+                <artifactId>base</artifactId>
+                <version>${com.google.jsinterop.base.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.jsinterop</groupId>


### PR DESCRIPTION
### What does this PR do?
Add jsinterop base dependency management
- [X] CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15053

there is no dependency except the jsinterop annotation dependency
http://central.maven.org/maven2/com/google/jsinterop/base/1.0.0-RC1/base-1.0.0-RC1.pom

