### PR TITLE
Add the `com.auth0.jwks-rsa` library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
+        <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
         <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.19.1</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
@@ -159,6 +160,11 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${ch.qos.logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.auth0</groupId>
+                <artifactId>jwks-rsa</artifactId>
+                <version>${com.auth0.jwks-rsa.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.beust</groupId>


### PR DESCRIPTION
### What does this PR do?

This PR adds the `com.auth0.jwks-rsa` library which is required to allow switching to an alternate OIDC provider (provided that it emits access tokens as JWT tokens).

### What issues does this PR fix or reference?

This is related to the implementation required in upstream Che, for
issues
https://github.com/redhat-developer/rh-che/issues/502 and
https://github.com/redhat-developer/rh-che/issues/525

### Related CQs

This PR should only be merged after CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15543 has been approved.
