### PR TITLE
Add dependencies for JPA coordination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
         <org.jgroups.kubernetes.version>0.9.3</org.jgroups.kubernetes.version>
-        <org.jgroups.version>3.5.1.Final</org.jgroups.version>
+        <org.jgroups.version>3.6.15.Final</org.jgroups.version>
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.postgresql.version>9.4-1201-jdbc41</org.postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
         <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
+        <org.jgroups.kubernetes.version>0.9.3</org.jgroups.kubernetes.version>
+        <org.jgroups.version>3.5.1.Final</org.jgroups.version>
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
         <org.postgresql.version>9.4-1201-jdbc41</org.postgresql.version>
@@ -959,6 +961,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.extension</artifactId>
+                <version>${org.eclipse.persistence.eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.jpa</artifactId>
                 <version>${org.eclipse.persistence.eclipselink.version}</version>
             </dependency>
@@ -1057,6 +1064,16 @@
                 <groupId>org.jdom</groupId>
                 <artifactId>jdom</artifactId>
                 <version>${org.jdom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jgroups</groupId>
+                <artifactId>jgroups</artifactId>
+                <version>${org.jgroups.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jgroups.kubernetes</groupId>
+                <artifactId>kubernetes</artifactId>
+                <version>${org.jgroups.kubernetes.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
### What does this PR do?
Adds `jgroups`, `KUBE_PING` and `eclipselink-extensions` for JPA cache coordination.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8922

CQ's:
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15798
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15799