### PR TITLE
Updating k8s / openshift client to the latest 3.1.12 version and okhttp to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,15 +48,15 @@
         <com.googlecode.gson.version>2.8.2</com.googlecode.gson.version>
         <com.h2database.version>1.4.196</com.h2database.version>
         <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
-        <com.squareup.okhttp3.version>3.8.1</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.9.1</com.squareup.okhttp3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>3.1.0</io.fabric8.kubernetes-client>
-        <io.fabric8.kubernetes-model>2.0.4</io.fabric8.kubernetes-model>
-        <io.fabric8.openshift-client.version>3.1.0</io.fabric8.openshift-client.version>
+        <io.fabric8.kubernetes-client>3.1.12</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-model>2.0.9</io.fabric8.kubernetes-model>
+        <io.fabric8.openshift-client.version>3.1.12</io.fabric8.openshift-client.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
### What does this PR do?
Updating k8s / openshift client to the latest 3.1.12 version and okhttp to 3.9.1

CQ for okhttp 3.9.1 - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16538
Service releases of k8s / openshift clients do no require CQ 

### What issues does this PR fix or reference?
required for proper solution of  https://github.com/redhat-developer/rh-che/pull/688
passing `identity_id` via `Impersonate-User` header which is only supported starting from 3.1.7 version

### Tests written?
No

### Docs updated?
No
